### PR TITLE
Multiline response with single <nl> line ending are not handled

### DIFF
--- a/src/ftpclass.cc
+++ b/src/ftpclass.cc
@@ -2743,6 +2743,7 @@ int Ftp::ReceiveOneLine()
       if(nl==resp+resp_size-1 && now-conn->control_recv->EventTime()>5)
       {
 	 LogError(1,"server bug: single <NL>");
+	 nl=find_char(resp,resp_size,'\n');
 	 line_len=nl-resp;
 	 skip_len=nl-resp+1;
 	 break;


### PR DESCRIPTION
Once wrong end of line is detected, restart the parsing of the response to handle all the lines. This correction is not very efficient but is working.
