### PR TITLE
Move adding of info to file_set to after use.

### DIFF
--- a/src/SFtp.cc
+++ b/src/SFtp.cc
@@ -918,8 +918,6 @@ void SFtp::HandleExpect(Expect *e)
 	    if(!file_set)
 	       file_set=new FileSet;
 	    FileInfo *info=MakeFileInfo(a);
-	    if(info)
-	       file_set->Add(info);
 	    if(mode==LIST)
 	    {
 	       file_buf->Put(a->name);
@@ -941,6 +939,8 @@ void SFtp::HandleExpect(Expect *e)
 		  file_buf->Put("\n");
 	       }
 	    }
+	    if(info)
+	       file_set->Add(info);
 	 }
 	 if(r->Eof())
 	    goto eof;


### PR DESCRIPTION
This moves putting the file info into the file_set after its last
use in the case block, since adding it to the list causes the info
object to be deleted if an identically named entry already exists.

The way it was before would cause semi-random segfaults if the
longname wasn't set, since info would have been deinitialized
on the second branch (else if (info)).

We found this problem when a user's sftp server was returning 
multiple directories with the same name (which is dumb, but 
should not crash the client).
