### PR TITLE
Fix mirror mode if the Location is a full URL

### DIFF
--- a/src/MirrorJob.cc
+++ b/src/MirrorJob.cc
@@ -660,9 +660,9 @@ void MirrorJob::HandleChdir(FileAccessRef& session, int &redirections)
 	    char *loc=alloca_strdup(loc_c);
 	    ParsedURL u(loc,true);
 
+	    bool is_file=(last_char(loc)!='/');
 	    if(!u.proto)
 	    {
-	       bool is_file=(last_char(loc)!='/');
 	       FileAccess::Path new_cwd(session->GetNewCwd());
 	       new_cwd.Change(0,is_file,loc);
 	       session->PathVerify(new_cwd);
@@ -671,7 +671,9 @@ void MirrorJob::HandleChdir(FileAccessRef& session, int &redirections)
 	    }
 	    session->Close(); // loc_c is no longer valid.
 	    session=FA::New(&u);
-	    session->Chdir(u.path);
+	    FileAccess::Path new_cwd(session->GetCwd());
+	    new_cwd.Change(u.path,is_file);
+	    session->PathVerify(new_cwd);
 	    return;
 	 }
       }


### PR DESCRIPTION
Previously lftp failed to mirror location if the server redirected the client to another location and the Location in response was full URL

Fixes issue #105 

Signed-off-by: Tomas Hozza <thozza@redhat.com>