### PR TITLE
lftp-4.6.1.20150401/src/.libs/liblftp-tasks.so: undefined reference to `...

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -83,7 +83,7 @@ liblftp_tasks_la_SOURCES = PollVec.cc PollVec.h SMTask.cc SMTask.h ProcWait.cc\
  IdNameCache.h PatternSet.cc PatternSet.h LocalDir.cc LocalDir.h
 liblftp_tasks_la_LIBADD = $(TASK_MODULES_STATIC) $(TRIO) $(GNULIB)\
  $(LIB_CRYPTO) $(INET_PTON_LIB) $(LIB_CLOCK_GETTIME) $(SOCKSLIBS)\
- $(LIBSOCKET) $(LIB_POLL) $(LIB_SELECT) $(LTLIBINTL) $(LTLIBICONV)
+ $(LIBSOCKET) $(LIB_POLL) $(LIB_SELECT) $(LTLIBINTL) $(LTLIBICONV) liblftp-network.la
 
 liblftp_jobs_la_SOURCES = Job.cc Job.h CmdExec.cc CmdExec.h\
  commands.cc mgetJob.h mgetJob.cc SysCmdJob.cc SysCmdJob.h rmJob.cc rmJob.h\


### PR DESCRIPTION
...is_ipv6_address(char const*)'