### PR TITLE
Mobileum

### DIFF
--- a/src/FileCopy.cc
+++ b/src/FileCopy.cc
@@ -162,6 +162,7 @@ int FileCopy::Do()
       }
       if(get->Error() && get->Size()==0)
       {
+	 put->DontVerify();
 	 if(put->GetPos()>0)
 	 {
 	    put->PutEOF();
@@ -866,8 +867,11 @@ int FileCopyPeerFA::Do()
    if(verify)
    {
       if(verify->Error())
+      {
 	 SetError(verify->ErrorText());
-      if(verify->Done())
+	 m=MOVED;
+      }
+      else if(verify->Done())
       {
 	 if(suggested_filename && auto_rename)
 	 {
@@ -1509,8 +1513,11 @@ int FileCopyPeerFDStream::Do()
    if(verify)
    {
       if(verify->Error())
+      {
 	 SetError(verify->ErrorText());
-      if(verify->Done())
+	 m=MOVED;
+      }
+      else if(verify->Done())
       {
 	 if(suggested_filename && stream && stream->full_name && auto_rename)
 	 {

--- a/src/Fish.cc
+++ b/src/Fish.cc
@@ -31,6 +31,7 @@
 #include "misc.h"
 #include "log.h"
 #include "ArgV.h"
+#include <malloc.h>
 
 #define super SSH_Access
 
@@ -1174,7 +1175,11 @@ void FishDirList::ResumeInternal()
 static FileSet *ls_to_FileSet(const char *b,int len)
 {
    FileSet *set=new FileSet;
-   char *buf=string_alloca(len+1);
+   char *buf=(char*) malloc(len+1);
+   if (buf == NULL) {
+      fprintf(stderr, "failed to allocate memory.\n");
+      exit(-1);
+   }
    memcpy(buf,b,len);
    buf[len]=0;
    for(char *line=strtok(buf,"\n"); line; line=strtok(0,"\n"))
@@ -1192,6 +1197,8 @@ static FileSet *ls_to_FileSet(const char *b,int len)
 
       set->Add(f);
    }
+
+   free(buf);
    return set;
 }
 

--- a/src/MirrorJob.cc
+++ b/src/MirrorJob.cc
@@ -1044,12 +1044,11 @@ int   MirrorJob::Do()
 	       goto pre_TARGET_CHMOD;
 	    goto pre_TARGET_MKDIR;
 	 }
-	 const char *target_name_rel=dir_file(target_relative_dir,file->name);
-	 target_name_rel=alloca_strdup(target_name_rel);
 	 if(!(flags&DELETE))
 	 {
 	    if(flags&REPORT_NOT_DELETED)
 	    {
+		const char *target_name_rel=dir_file(target_relative_dir,file->name);
 	       if(file->TypeIs(file->DIRECTORY))
 		  Report(_("Old directory `%s' is not removed"),target_name_rel);
 	       else
@@ -1090,6 +1089,7 @@ int   MirrorJob::Do()
 		  j->Recurse();
 	    }
 	 }
+	const char *target_name_rel=dir_file(target_relative_dir,file->name);
 	 if(file->TypeIs(file->DIRECTORY))
 	    Report(_("Removing old directory `%s'"),target_name_rel);
 	 else


### PR DESCRIPTION
1. Fix "fixed large stack usage when parsing fish directory listings" in master branch not working fine. Committed alternate fix through c3fe48d79fa0341897cdb61a5782ae91fe9835b2 commit.

2. target_name_rel in MirrorJob.cc was getting list of files present at target side and storing it using alloca on stack. This list can grow very high and can result in stack overflow.
