### PR TITLE
Mobileum

### DIFF
--- a/src/Fish.cc
+++ b/src/Fish.cc
@@ -31,6 +31,7 @@
 #include "misc.h"
 #include "log.h"
 #include "ArgV.h"
+#include <malloc.h>
 
 #define super SSH_Access
 
@@ -1174,30 +1175,30 @@ void FishDirList::ResumeInternal()
 static FileSet *ls_to_FileSet(const char *b,int len)
 {
    FileSet *set=new FileSet;
-   while(len>0) {
-      // find one line
-      const char *line=b;
-      int ll=len;
-      const char *eol=find_char(b,len,'\n');
-      if(eol) {
-	 ll=eol-b;
-	 len-=ll+1;
-	 b+=ll+1;
-      } else {
-	 len=0;
-      }
+   char *buf=(char*) malloc(len+1);
+   if (buf == NULL) {
+        fprintf(stderr, "failed to allocate memory.\n");
+        exit(-1);
+   }
+   memcpy(buf,b,len);
+   buf[len]=0;
+   for(char *line=strtok(buf,"\n"); line; line=strtok(0,"\n"))
+   {
+      int ll=strlen(line);
       if(ll && line[ll-1]=='\r')
-	 --ll;
+	 line[--ll]=0;
       if(ll==0)
 	 continue;
 
-      FileInfo *f=FileInfo::parse_ls_line(line,ll,"GMT");
+      FileInfo *f=FileInfo::parse_ls_line(line,"GMT");
 
       if(!f)
 	 continue;
 
       set->Add(f);
    }
+
+   free(buf);
    return set;
 }
 

--- a/src/MirrorJob.cc
+++ b/src/MirrorJob.cc
@@ -1071,12 +1071,11 @@ int   MirrorJob::Do()
 	       goto pre_TARGET_CHMOD;
 	    goto pre_TARGET_MKDIR;
 	 }
-	 const char *target_name_rel=dir_file(target_relative_dir,file->name);
-	 target_name_rel=alloca_strdup(target_name_rel);
 	 if(!(flags&DELETE))
 	 {
 	    if(flags&REPORT_NOT_DELETED)
 	    {
+	       const char *target_name_rel=dir_file(target_relative_dir,file->name);
 	       if(file->TypeIs(file->DIRECTORY))
 		  Report(_("Old directory `%s' is not removed"),target_name_rel);
 	       else
@@ -1117,6 +1116,7 @@ int   MirrorJob::Do()
 		  j->Recurse();
 	    }
 	 }
+	 const char *target_name_rel=dir_file(target_relative_dir,file->name);
 	 if(file->TypeIs(file->DIRECTORY))
 	    Report(_("Removing old directory `%s'"),target_name_rel);
 	 else
@@ -1251,8 +1251,6 @@ int   MirrorJob::Do()
 	    goto pre_FINISHING;
 	 if(file->TypeIs(file->DIRECTORY))
 	    continue;
-	 const char *source_name_rel=dir_file(source_relative_dir,file->name);
-	 source_name_rel=alloca_strdup(source_name_rel);
 	 if(script)
 	 {
 	    ArgV args("rm");
@@ -1269,6 +1267,7 @@ int   MirrorJob::Do()
 	    j->cmdline.set_allocated(args->Combine());
 	    JobStarted(j);
 	 }
+	 const char *source_name_rel=dir_file(source_relative_dir,file->name);
 	 Report(_("Removing source file `%s'"),source_name_rel);
       }
       break;


### PR DESCRIPTION
1. Fix "fixed large stack usage when parsing fish directory listings" in master branch not working fine. Committed alternate fix through ad0108b4ff9934ceae7e994c2557a66e8662e8f6 commit.

2. target_name_rel in MirrorJob.cc was getting list of files present at target side and storing it using alloca on stack. This list can grow very high and can result in stack overflow.