### PR TITLE
mirror: don't set u+rwx on directories if already set

### DIFF
--- a/src/MirrorJob.cc
+++ b/src/MirrorJob.cc
@@ -818,7 +818,9 @@ int   MirrorJob::Do()
 	 {
 	    if(S_ISDIR(st.st_mode))
 	    {
-	       if(!script_only)
+	       // try to enable write access
+	       // only if not enabled as chmod can clear sgid flags on directories
+	       if(!script_only && (st.st_mode!=(st.st_mode|0700)))
 		  chmod(target_dir,st.st_mode|0700);
 	       create_target_dir=false;
 	       goto pre_CHANGING_DIR_TARGET;

--- a/src/MirrorJob.cc
+++ b/src/MirrorJob.cc
@@ -423,7 +423,11 @@ void  MirrorJob::HandleFile(FileInfo *file)
 	    {
 	       if(S_ISDIR(st.st_mode))
 	       {
-		  chmod(target_name,st.st_mode|0700);
+		  // try to enable write access
+		  // only if not enabled as chmod can clear sgid flags on directories
+		  if(st.st_mode!=(st.st_mode|0700)) {
+		    chmod(target_name,st.st_mode|0700);
+		  }
 		  create_target_dir=false;
 	       }
 	       else


### PR DESCRIPTION
Running chmod will clear sgid permissions on directories when current user
is not a member of directory group even when actually nothing is explicitly
changed.