### PR TITLE
Added bookmark cookies for prompt.

### DIFF
--- a/doc/lftp.1
+++ b/doc/lftp.1
@@ -1344,6 +1344,13 @@ a backslash
 .B \e?
 skips next character if previous substitution was empty.
 .TP
+.B \eb
+The bookmark which the connected remote site corresponds to.
+.TP
+.B \eB
+The bookmark which the connected remote site corresponds to, if available.
+If there is no bookmark associated, the hostname (see \fB\\h\fP) is used.
+.TP
 .B \e[
 begin a sequence of non-printing characters, which could be used to
 embed a terminal control sequence into the prompt

--- a/src/CmdExec.cc
+++ b/src/CmdExec.cc
@@ -906,6 +906,8 @@ const char *CmdExec::FormatPrompt(const char *scan)
       { 'L', lcwdb },
       { '[', StartIgn },
       { ']', EndIgn },
+      { 'b', session->GetBookmark() },
+      { 'B', session->GetBookmark()?session->GetBookmark():session->GetHostName() },
       { 0, "" }
    };
    static xstring_c prompt;

--- a/src/FileAccess.cc
+++ b/src/FileAccess.cc
@@ -39,9 +39,11 @@
 #include "ConnectionSlot.h"
 #include "SignalHook.h"
 #include "FileGlob.h"
+#include "bookmark.h"
 #ifdef WITH_MODULES
 # include "module.h"
 #endif
+
 
 xlist_head<FileAccess> FileAccess::all_fa;
 const FileAccessRef FileAccessRef::null;
@@ -254,6 +256,10 @@ bool FileAccess::SameSiteAs(const FileAccess *fa) const
    return SameProtoAs(fa);
 }
 
+const char *FileAccess::GetBookmark() const
+{
+   return lftp_bookmarks.LookupFirstKeyByValue(GetConnectURL(2));
+}
 const char *FileAccess::GetFileURL(const char *f,int flags) const
 {
    static xstring url;

--- a/src/FileAccess.cc
+++ b/src/FileAccess.cc
@@ -258,7 +258,7 @@ bool FileAccess::SameSiteAs(const FileAccess *fa) const
 
 const char *FileAccess::GetBookmark() const
 {
-   return lftp_bookmarks.LookupFirstKeyByValue(GetConnectURL(2));
+   return lftp_bookmarks.LookupFirstKeyByValue(GetConnectURL(WITH_PASSWORD));
 }
 const char *FileAccess::GetFileURL(const char *f,int flags) const
 {

--- a/src/FileAccess.h
+++ b/src/FileAccess.h
@@ -205,6 +205,9 @@ public:
    const char  *GetPort() const { return portname; }
    const char  *GetConnectURL(int flags=0) const;
    const char  *GetFileURL(const char *file,int flags=0) const;
+
+   const char  *GetBookmark() const;
+
    enum { NO_PATH=1,WITH_PASSWORD=2,NO_PASSWORD=4,NO_USER=8 };
    const char *GetLastDisconnectCause() const { return last_disconnect_cause; }
 

--- a/src/keyvalue.cc
+++ b/src/keyvalue.cc
@@ -174,10 +174,26 @@ KeyValueDB::Pair **KeyValueDB::LookupPair(const char *key) const
    return 0;
 }
 
+KeyValueDB::Pair **KeyValueDB::LookupFirstPairByValue(const char *value) const
+{
+   for(const Pair * const*p=&chain; *p; p=&(*p)->next)
+   {
+      if((*p)->ValueCompare(value)==0)
+	 return const_cast<KeyValueDB::Pair **>(p);
+   }
+   return 0;
+}
+
 const char *KeyValueDB::Lookup(const char *key) const
 {
    const Pair * const*p=LookupPair(key);
    return p ? (*p)->value.get() : 0;
+}
+
+const char *KeyValueDB::LookupFirstKeyByValue(const char *value) const
+{
+   const Pair * const*p=LookupFirstPairByValue(value);
+   return p ? (*p)->key.get() : 0;
 }
 
 int KeyValueDB::Lock(int fd,int type)

--- a/src/keyvalue.h
+++ b/src/keyvalue.h
@@ -47,6 +47,11 @@ public:
 	 {
 	    return strcmp(s,key);
 	 }
+
+      int ValueCompare(const char *s) const
+         {
+            return strcmp(s,value);
+         }
       void SetValue(const char *v) { value.set(v); }
    };
 
@@ -60,6 +65,7 @@ protected:
 	 delete to_free;
       }
    Pair **LookupPair(const char *key) const;
+   Pair **LookupFirstPairByValue(const char *value) const;
    void AddPair(Pair *p)
       {
 	 p->next=chain;
@@ -80,6 +86,7 @@ public:
    void Add(const char *id,const char *value);
    void Remove(const char *id);
    const char *Lookup(const char *id) const;
+   const char *LookupFirstKeyByValue(const char *value) const;
    void Empty()
       {
 	 while(chain)
@@ -127,6 +134,11 @@ public:
    static int KeyCompare(const Pair *a,const Pair *b)
       {
 	 return strcmp(a->key,b->key);
+      }
+
+   static int ValueCompare(const Pair *a,const Pair *b)
+      {
+         return strcmp(a->value,b->value);
       }
    static int VKeyCompare(const void *a,const void *b);
 };


### PR DESCRIPTION
This patch addes two cookies for the prompt:

```
\b - Will display the bookmark, which corresponds to the current remote site.
\B - If a bookmark is found, it acts like \b. Otherwise like \h.
```

This allows to have a prompt like:

`[lftp] user@Bookmark ~>`
