### PR TITLE
sftp: flush file buffer in DONE state before returning EOF

### DIFF
--- a/src/SFtp.cc
+++ b/src/SFtp.cc
@@ -1169,7 +1169,7 @@ int SFtp::Read(Buffer *buf,int size)
       return error_code;
    if(mode==CLOSED)
       return 0;
-   if(state==DONE)
+   if(state==DONE && !(file_buf && file_buf->Size()>0))
       return 0;	  // eof
    if(state==FILE_RECV)
    {
@@ -1181,7 +1181,10 @@ int SFtp::Read(Buffer *buf,int size)
 	 if(entity_size<0 || request_pos<entity_size || RespQueueSize()<2)
 	    RequestMoreData();
       }
+   }
 
+   if(file_buf && file_buf->Size()>0)
+   {
       const char *buf1;
       int size1;
       file_buf->Get(&buf1,&size1);


### PR DESCRIPTION
This fixes a problem with sftp causing "file size decreased during transfer" errors, which was seen with lftp versions before 4.5.0. The problem wasn't reproduced in 4.5.0 and later versions, but it seems this might be just a side effect of the changes in SMTask which were included in 4.5.0, and this situation could theoretically still happen, if not with the current code, maybe later with future changes.