### PR TITLE
Resolver.cc: Cast address to IN6_IS_ADDR_LINKLOCAL

### DIFF
--- a/src/Resolver.cc
+++ b/src/Resolver.cc
@@ -318,7 +318,7 @@ void Resolver::AddAddress(int family,const char *address,int len, unsigned int s
    case AF_INET6:
       if(sizeof(add.in6.sin6_addr) != len)
          return;
-      if(IN6_IS_ADDR_LINKLOCAL(address) && scope==0) {
+      if(IN6_IS_ADDR_LINKLOCAL((const struct in6_addr*)address) && scope==0) {
 	 error=_("Link-local IPv6 address should have a scope");
 	 return;
       }


### PR DESCRIPTION
The `IN6_IS_ADDR_LINKLOCAL` is specified to take a `const struct in6_addr*`, and to be portable across platforms a cast seems to be needed. Fixes #306.