### PR TITLE
m4: add -R option for runtime path to libraries

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -306,7 +306,7 @@ fi
 
 AX_CHECK_ZLIB([
    AC_SUBST([ZLIB],[-lz])
-   AC_SUBST([ZLIB_LDFLAGS],["-L${ZLIB_HOME}/lib"])
+   AC_SUBST([ZLIB_LDFLAGS],["-L${ZLIB_HOME}/lib -R${ZLIB_HOME}/lib"])
    AC_SUBST([ZLIB_CPPFLAGS],["-I${ZLIB_HOME}/include"])
 ],[
    AC_MSG_ERROR([cannot find -lz library, install zlib-devel package])

--- a/m4/ax_check_zlib.m4
+++ b/m4/ax_check_zlib.m4
@@ -105,7 +105,7 @@ then
   ZLIB_OLD_LDFLAGS="$LDFLAGS"
   ZLIB_OLD_CPPFLAGS="$CPPFLAGS"
   if test -n "${ZLIB_HOME}"; then
-        LDFLAGS="$LDFLAGS -L${ZLIB_HOME}/lib -R${ZLIB_HOME}/lib"
+        LDFLAGS="$LDFLAGS -L${ZLIB_HOME}/lib"
         CPPFLAGS="$CPPFLAGS -I${ZLIB_HOME}/include"
   fi
   AC_LANG_SAVE
@@ -119,6 +119,7 @@ then
     # If both library and header were found, action-if-found
     #
     m4_ifblank([$1],[
+		LDFLAGS="$LDFLAGS -R${ZLIB_HOME}/lib"
                 LIBS="-lz $LIBS"
                 AC_DEFINE([HAVE_LIBZ], [1],
                           [Define to 1 if you have `z' library (-lz)])

--- a/m4/ax_check_zlib.m4
+++ b/m4/ax_check_zlib.m4
@@ -102,10 +102,10 @@ then
 	  ZLIB_HOME=""
 	done
 
-  ZLIB_OLD_LDFLAGS=$LDFLAGS
-  ZLIB_OLD_CPPFLAGS=$CPPFLAGS
+  ZLIB_OLD_LDFLAGS="$LDFLAGS"
+  ZLIB_OLD_CPPFLAGS="$CPPFLAGS"
   if test -n "${ZLIB_HOME}"; then
-        LDFLAGS="$LDFLAGS -L${ZLIB_HOME}/lib"
+        LDFLAGS="$LDFLAGS -L${ZLIB_HOME}/lib -R${ZLIB_HOME}/lib"
         CPPFLAGS="$CPPFLAGS -I${ZLIB_HOME}/include"
   fi
   AC_LANG_SAVE
@@ -119,8 +119,6 @@ then
     # If both library and header were found, action-if-found
     #
     m4_ifblank([$1],[
-                CPPFLAGS="$CPPFLAGS -I${ZLIB_HOME}/include"
-                LDFLAGS="$LDFLAGS -L${ZLIB_HOME}/lib"
                 LIBS="-lz $LIBS"
                 AC_DEFINE([HAVE_LIBZ], [1],
                           [Define to 1 if you have `z' library (-lz)])

--- a/m4/ax_lib_expat.m4
+++ b/m4/ax_lib_expat.m4
@@ -109,7 +109,7 @@ AC_DEFUN([AX_LIB_EXPAT],
 
     if test -n "$expat_prefix"; then
         expat_include_dir="$expat_prefix/include"
-        expat_ld_flags="-L$expat_prefix/lib -R$expat_prefix/lib"
+        expat_ld_flags="-L$expat_prefix/lib"
         expat_lib_flags="-lexpat"
         run_expat_test="yes"
     elif test "$expat_requested" = "yes"; then
@@ -180,7 +180,7 @@ p = NULL;
                 )],
                 [
                 EXPAT_LIBS="$expat_lib_flags"
-                EXPAT_LDFLAGS="$expat_ld_flags"
+                EXPAT_LDFLAGS="$expat_ld_flags -R$expat_prefix/lib"
                 expat_lib_found="yes"
                 AC_MSG_RESULT([found])
                 ],

--- a/m4/ax_lib_expat.m4
+++ b/m4/ax_lib_expat.m4
@@ -109,7 +109,7 @@ AC_DEFUN([AX_LIB_EXPAT],
 
     if test -n "$expat_prefix"; then
         expat_include_dir="$expat_prefix/include"
-        expat_ld_flags="-L$expat_prefix/lib"
+        expat_ld_flags="-L$expat_prefix/lib -R$expat_prefix/lib"
         expat_lib_flags="-lexpat"
         run_expat_test="yes"
     elif test "$expat_requested" = "yes"; then

--- a/m4/lftp_lib_readline.m4
+++ b/m4/lftp_lib_readline.m4
@@ -107,7 +107,7 @@ AC_DEFUN([lftp_LIB_READLINE],
 	if test -f "$readline_include_dir/readline/readline.h"; then
 	    readline_include_dir="$readline_include_dir/readline"
 	fi
-        readline_ld_flags="-L$readline_prefix/lib -R$readline_prefix/lib"
+        readline_ld_flags="-L$readline_prefix/lib"
         readline_lib_flags="-lreadline"
         run_readline_test="yes"
     elif test "$readline_requested" = "yes"; then
@@ -182,7 +182,7 @@ rl_completion_matches(0,0);
                 )],
                 [
                 READLINE_LIBS="$readline_lib_flags"
-                READLINE_LDFLAGS="$readline_ld_flags"
+                READLINE_LDFLAGS="$readline_ld_flags -R$readline_prefix/lib"
                 readline_lib_found="yes"
                 AC_MSG_RESULT([found])
                 ],

--- a/m4/lftp_lib_readline.m4
+++ b/m4/lftp_lib_readline.m4
@@ -107,7 +107,7 @@ AC_DEFUN([lftp_LIB_READLINE],
 	if test -f "$readline_include_dir/readline/readline.h"; then
 	    readline_include_dir="$readline_include_dir/readline"
 	fi
-        readline_ld_flags="-L$readline_prefix/lib"
+        readline_ld_flags="-L$readline_prefix/lib -R$readline_prefix/lib"
         readline_lib_flags="-lreadline"
         run_readline_test="yes"
     elif test "$readline_requested" = "yes"; then


### PR DESCRIPTION
-R option is needed for executable to find the library in a non-standard place.

Also fixed zlib check (save flags properly; avoid duplicating the flags).

May fix #336 (please check)