### PR TITLE
ftp: Send 'OPTS MLST' after login

### DIFF
--- a/src/ftpclass.cc
+++ b/src/ftpclass.cc
@@ -1606,8 +1606,13 @@ int   Ftp::Do()
 	 conn->SendCmd("FEAT");
 	 expect->Push(Expect::FEAT);
       }
-      else if(conn->tune_after_login)
-	 TuneConnectionAfterFEAT();
+      else
+      {
+	 if(conn->tune_after_login)
+	    TuneConnectionAfterFEAT();
+	 if(conn->mlst_attr_supported)
+	    SendOPTS_MLST();
+      }
       SendSiteGroup();
       SendSiteIdle();
       SendSiteCommands();
@@ -3977,7 +3982,7 @@ void Ftp::TuneConnectionAfterFEAT()
       conn->SendCmd2("HOST",hostname);
       expect->Push(Expect::IGNORE);
    }
-   if(conn->mlst_attr_supported)
+   if(conn->try_feat_after_login && conn->mlst_attr_supported)
       SendOPTS_MLST();
    if(proxy)
       conn->epsv_supported=false;


### PR DESCRIPTION
RFC 3659 says that the server is not required to accept the 'OPTS MLST'
command before authentication. So send it after login.