### PR TITLE
Fix crashes when some external APIs fail

### DIFF
--- a/src/Torrent.cc
+++ b/src/Torrent.cc
@@ -3830,7 +3830,8 @@ int TorrentListener::Do()
       }
    bound:
       if(type==SOCK_STREAM)
-	 listen(sock,5);
+	 if(listen(sock,5) < 0)
+             LogError(0,"listen failed: %s", strerror(errno));
 
       // get the allocated port
       socklen_t addr_len=sizeof(addr);

--- a/src/commands.cc
+++ b/src/commands.cc
@@ -2205,7 +2205,8 @@ CMD(debug)
    }
 
    if(debug_file_name && trunc)
-      truncate(debug_file_name,0);
+      if(truncate(debug_file_name,0) < 0)
+         fprintf(stderr, "truncate failed: %s\n", strerror(errno));
 
    const char *c="debug";
    ResMgr::Set("log:file",c,debug_file_name?debug_file_name:"");

--- a/src/ftpclass.cc
+++ b/src/ftpclass.cc
@@ -1867,7 +1867,8 @@ int   Ftp::Do()
 	 }
 
 	 if(!GetFlag(PASSIVE_MODE))
-	    listen(conn->data_sock,1);
+	    if (listen(conn->data_sock,1) < 0)
+		LogError(0,"listen failed: %s", strerror(errno));
 
 	 // get the allocated port
 	 addr_len=sizeof(conn->data_sa);


### PR DESCRIPTION
Hi,

I'm a PhD student. I analyzed the lftp source code and found some potential API bugs that may cause crashes.
These crashes are mainly caused by insufficient error handling of API functions like listen or truncate.
I think it's unsafe to assume the library function would be correct. It would be better if we could handle the error properly (at least print error message).

Best,
Zhouyang