### PR TITLE
fix(edit): add compatibility with fish

### DIFF
--- a/src/EditJob.cc
+++ b/src/EditJob.cc
@@ -89,7 +89,11 @@ int EditJob::Do()
       struct stat st;
       int res=stat(temp_file,&st);
       mtime=(res>=0?st.st_mtime:NO_DATE);
-      xstring cmd("${EDITOR:-vi} ");
+      const char *bin=getenv("EDITOR");
+      if (bin==NULL)
+         bin="vi";
+      xstring cmd(bin);
+      cmd.append(" ");
       cmd.append(shell_encode(temp_file));
       editor=new SysCmdJob(cmd);
       AddWaiting(editor);

--- a/src/commands.cc
+++ b/src/commands.cc
@@ -3004,12 +3004,13 @@ CMD(bookmark)
    {
       lftp_bookmarks.Remove(""); // force bookmark file creation
 
-      xstring cmd0("exec ${EDITOR:-vi} ");
-      cmd0.append(shell_encode(lftp_bookmarks.GetFilePath()));
-      xstring cmd1("/bin/sh -c ");
-      cmd1.append(shell_encode(cmd0));
-
-      parent->PrependCmd(xstring::get_tmp("shell ").append_quoted(cmd1));
+      const char *bin=getenv("EDITOR");
+      if (bin==NULL)
+         bin="vi";
+      xstring cmd(bin);
+      cmd.append(" ");
+      cmd.append(shell_encode(lftp_bookmarks.GetFilePath()));
+      parent->PrependCmd(xstring::get_tmp("shell ").append_quoted(cmd));
    }
    else if(!strcasecmp(op,"import"))
    {


### PR DESCRIPTION
Fish does not allow variable expansion `${EDITOR:-vi}`:

> fish: Variables may not be used as commands. In fish, please define a function or use 'eval $EDITOR:-vi'.
> ${EDITOR:-vi} /home/simon/.lftp/edit/simon-314159.README