### PR TITLE
Add missing -f in readline test

### DIFF
--- a/m4/lftp_lib_readline.m4
+++ b/m4/lftp_lib_readline.m4
@@ -70,7 +70,7 @@ AC_DEFUN([lftp_LIB_READLINE],
         dnl Default behavior is implicit yes
         if test -f /usr/local/include/readline.h -o -f /usr/local/include/readline/readline.h; then
             readline_prefix=/usr/local
-        elif test -f /usr/include/readline.h -o /usr/include/readline/readline.h; then
+        elif test -f /usr/include/readline.h -o -f /usr/include/readline/readline.h; then
             readline_prefix=/usr
         else
             readline_prefix=""


### PR DESCRIPTION
Hi,

There is a missing '-f' in test args, leading to the test being true even if the file does not exist. Find attached a patch to fix that problem.

Best regards,
Ganael.