### PR TITLE
Replace symlink after removing previous symlink

### DIFF
--- a/src/SFtp.cc
+++ b/src/SFtp.cc
@@ -648,6 +648,8 @@ void SFtp::SendRequest()
 	 SetError(NOT_SUPP);
 	 break;
       }
+      if (mode==SYMLINK)
+         SendRequest(new Request_REMOVE(WirePath(file1)),Expect::IGNORE);
       if(protocol_version>=6)
 	 SendRequest(new Request_LINK(mode==SYMLINK?lc_to_utf8(file):WirePath(file),WirePath(file1),mode==SYMLINK),Expect::DEFAULT);
       else


### PR DESCRIPTION
Resolves issue #456.

With this change, `mirror -R` can replace symlinks over sftp.

One side-effect is that `ln -s` will also replace symlinks, when this would normally be an error.

A better solution would allow `mirror -R` to replace symlinks without changing the behaviour of `ln -s`.  Any suggestions?