### PR TITLE
WIP pull request for epsv override

### DIFF
--- a/src/ResMgr.cc
+++ b/src/ResMgr.cc
@@ -816,6 +816,20 @@ const char *ResMgr::IPv6AddrValidate(xstring_c *value)
 }
 #endif
 
+const char *ResMgr::IPAddrValidate(xstring_c *value)
+{
+    if(!**value)
+      return 0;
+#if INET6
+    if(!is_ipv4_address(*value) && !is_ipv6_address(*value))
+      return _("Invalid IP numeric address");
+#else
+    if(!is_ipv4_address(*value))
+      return _("Invalid IPv4 numeric address");
+#endif
+    return 0;
+}
+
 const char *ResMgr::FileAccessible(xstring_c *value,int mode,bool want_dir)
 {
    if(!**value)

--- a/src/ResMgr.h
+++ b/src/ResMgr.h
@@ -120,6 +120,7 @@ public:
    static const char *ERegExpValidate(xstring_c *value);
    static const char *IPv4AddrValidate(xstring_c *value);
    static const char *IPv6AddrValidate(xstring_c *value);
+   static const char *IPAddrValidate(xstring_c *value);
    static const char *UNumberPairValidate(xstring_c *value);
    static const char *FileAccessible(xstring_c *value,int mode,bool want_dir=false);
    static const char *FileReadable(xstring_c *value);

--- a/src/resource.cc
+++ b/src/resource.cc
@@ -220,6 +220,7 @@ static ResType lftp_vars[] = {
    {"ftp:port-range",		 "full",  ResMgr::RangeValidate,0},
    {"ftp:port-ipv4",		 "",	  ResMgr::IPv4AddrValidate,0},
    {"ftp:prefer-epsv",		 "no",	  ResMgr::BoolValidate,0},
+   {"ftp:force-epsv-addr",       "",	  ResMgr::IPAddressValidate,0},
    {"ftp:proxy",		 "",	  FtpProxyValidate,0},
    {"ftp:proxy-auth-type",	 "user",  FtpProxyAuthTypeValidate,0},
    {"ftp:rest-list",		 "no",	  ResMgr::BoolValidate,0},


### PR DESCRIPTION
This is a work in progress pull request in order to allow the address for EPSV to be overridden.
This comes in to play when using proxies that do not handle the data connection, but only handle the control connection.

This adds a new option called "ftp:force-epsv-addr" that will be used for EPSV data connections.
