### PR TITLE
avoid information loss in both groff and mandoc

### DIFF
--- a/doc/lftp.1
+++ b/doc/lftp.1
@@ -788,7 +788,8 @@ FXP is automatically used for transfers between FTP servers, if possible.
 Some FTP servers hide dot-files by default (e.g. \fI.htaccess\fP), and show
 them only when LIST command is used with \-a option. In such case try to use
 `set ftp:list-options \-a'.
-.PP The recursion modes `newer' and `missing' conflict with \-\-scan\-all\-first,
+.PP
+The recursion modes `newer' and `missing' conflict with \-\-scan\-all\-first,
 \-\-depth\-first, \-\-no\-empty\-dirs and setting mirror:no\-empty\-dirs=true.
 
 .B mkdir


### PR DESCRIPTION
Avoid information loss in both groff and mandoc (".PP text" to ".PP\ntext").