### PR TITLE
travis.yml: don't try to run our builds in a container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: c++
-sudo: false
 
 compiler:
     - clang


### PR DESCRIPTION
Container environments are obsolete. See

 - https://blog.travis-ci.com/2018-10-04-combining-linux-infrastructures
 - https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

for the reasons given by Travis-CI.