### PR TITLE
In MaySendUDP() handle case when socket may not be available yet

### DIFF
--- a/src/Torrent.cc
+++ b/src/Torrent.cc
@@ -3905,6 +3905,8 @@ bool TorrentListener::MaySendUDP()
       last_sent_udp_count=0;
       last_sent_udp=now;
    }
+   if (sock==-1)
+      return false;
    // check if output buffer is available
    struct pollfd pfd;
    pfd.fd=sock;


### PR DESCRIPTION
It's possible that with DHT enabled, lftp will try to bind and
listen on a port, chosen from torrent:port-range and if other
lftp instances are running and ports from that range are already
in use, starting another lftp instance will SIGSEGV, as the sock
will be set to -1. See GitHub lftp issue #511 for more details.

To reproduce the issue, start lftp via:

   lftp -c 'torrent --dht-bootstrap=dht.example.com sample.torrent'

as many times as it's needed to exhaust torrent:port-range. Before
this change, lftp would segfault in PollVec::AddFD() with fd=-1.