### PR TITLE
Enable TLS by default

### DIFF
--- a/doc/lftp.1
+++ b/doc/lftp.1
@@ -1792,14 +1792,14 @@ if true, refuse to send password in clear when server does not support SSL.
 Default is false.
 .TP
 .BR ftp:ssl-protect-data \ (boolean)
-if true, request SSL connection for data transfers. This is cpu-intensive
-but provides privacy. Default is false.
+if true, request SSL connection for data transfers. This provides privacy and
+transmission error correction. Was cpu-intensive on old CPUs. Default is true.
 .TP
 .BR ftp:ssl-protect-fxp \ (boolean)
 if true, request SSL connection for data transfer between two FTP servers
 in FXP mode. CPSV or SSCN command will be used in that case. If SSL connection
 fails for some reason, lftp would try unprotected FXP transfer unless
-ftp:ssl-force is set for any of the two servers. Default is false.
+ftp:ssl-force is set for any of the two servers. Default is true.
 .TP
 .BR ftp:ssl-protect-list \ (boolean)
 if true, request SSL connection for file list transfers. Default is true.

--- a/src/resource.cc
+++ b/src/resource.cc
@@ -232,8 +232,8 @@ static ResType lftp_vars[] = {
 #if USE_SSL
    {"ftp:ssl-allow",		 "yes",   ResMgr::BoolValidate,0},
    {"ftp:ssl-force",		 "no",	  ResMgr::BoolValidate,0},
-   {"ftp:ssl-protect-data",	 "no",	  ResMgr::BoolValidate,0},
-   {"ftp:ssl-protect-fxp",	 "no",    ResMgr::BoolValidate,0},
+   {"ftp:ssl-protect-data",	 "yes",	  ResMgr::BoolValidate,0},
+   {"ftp:ssl-protect-fxp",	 "yes",    ResMgr::BoolValidate,0},
    {"ftp:ssl-protect-list",	 "yes",   ResMgr::BoolValidate,0},
    {"ftp:ssl-auth",		 "TLS",   AuthArgValidate,0},
    {"ftp:ssl-allow-anonymous",	 "no",	  ResMgr::BoolValidate,0},


### PR DESCRIPTION
Hi

I adjusted the defaults for more security.
The speed concerns are mitigated on most systems today, the argument is on this website: https://istlsfastyet.com/

If you would like me to change anything at this PR, please tell me.

Cheers,
Stefan