### PR TITLE
Stop sending ALLO commands by default

### DIFF
--- a/doc/lftp.1
+++ b/doc/lftp.1
@@ -1845,7 +1845,7 @@ if false, lftp does not send ABOR command but closes data connection
 immediately.
 .TP
 .BR ftp:use-allo \ (boolean)
-when true (default), lftp sends ALLO command before uploading a file.
+when true, lftp sends ALLO command before uploading a file.
 .TP
 .BR ftp:use-feat \ (boolean)
 when true (default), lftp uses FEAT command to determine extended features of

--- a/src/resource.cc
+++ b/src/resource.cc
@@ -248,7 +248,7 @@ static ResType lftp_vars[] = {
    {"ftp:sync-mode",		 "on",    ResMgr::BoolValidate,0},
    {"ftp:trust-feat",		 "no",	  ResMgr::BoolValidate,0},
    {"ftp:use-abor",		 "yes",   ResMgr::BoolValidate,0},
-   {"ftp:use-allo",		 "yes",   ResMgr::BoolValidate,0},
+   {"ftp:use-allo",		 "no",    ResMgr::BoolValidate,0},
    {"ftp:use-feat",		 "yes",   ResMgr::BoolValidate,0},
    {"ftp:use-fxp",		 "yes",   ResMgr::BoolValidate,0},
    {"ftp:use-hftp",		 "yes",   ResMgr::BoolValidate,0},


### PR DESCRIPTION
Currently, LFTP sends an ALLO command before each STOR, to ask the server to allocate storage space for the subsequent transfer.
But, the ALLO command is useless on any modern (or slightly modern) FTP server, and in many cases it is implemented as a no-operation.
As mentioned in one of the comments in the LFTP source code: "ALLO is usually ignored by servers, but send it anyway."

The result is that a redundant command is sent for each store command, and I can only think of disadvantages stemming from this fact.
Thus, I changed the default setting to not sending ALLO commands.