### PR TITLE
Fix some compilation issues

### DIFF
--- a/src/FileCopy.cc
+++ b/src/FileCopy.cc
@@ -36,7 +36,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <math.h>
+#include <cmath>
 #include <stddef.h>
 #include "FileCopy.h"
 #include "url.h"

--- a/src/NetAccess.cc
+++ b/src/NetAccess.cc
@@ -21,7 +21,7 @@
 
 #include <errno.h>
 #include <assert.h>
-#include <math.h>
+#include <cmath>
 #include <sys/types.h>
 
 #include "NetAccess.h"

--- a/src/ResMgr.cc
+++ b/src/ResMgr.cc
@@ -23,7 +23,7 @@
 #include <ctype.h>
 #include <unistd.h>
 #include <stdlib.h>
-#include <math.h>
+#include <cmath>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <errno.h>

--- a/src/Speedometer.cc
+++ b/src/Speedometer.cc
@@ -18,7 +18,7 @@
  */
 
 #include <config.h>
-#include <math.h>
+#include <cmath>
 #include <stdlib.h>
 #include "Speedometer.h"
 #include "misc.h"

--- a/src/TimeDate.cc
+++ b/src/TimeDate.cc
@@ -22,7 +22,6 @@
 #include "TimeDate.h"
 #include "misc.h"
 #include "SMTask.h"
-#include "strftime.h"
 
 void time_tuple::normalize()
 {

--- a/src/ftpclass.cc
+++ b/src/ftpclass.cc
@@ -42,7 +42,6 @@
 
 #include "ascii_ctype.h"
 #include "misc.h"
-#include "strftime.h"
 
 #define TELNET_IAC	'\377'	 //255	/* interpret as command: */
 #define TELNET_IP	'\364'	 //244	/* interrupt process--permanently */

--- a/src/misc.cc
+++ b/src/misc.cc
@@ -61,7 +61,6 @@ CDECL_END
 #include "url.h"
 #include "ResMgr.h"
 #include <mbswidth.h>
-#include "strftime.h"
 
 const char *dir_file(const char *dir,const char *file)
 {

--- a/trio/trio.c
+++ b/trio/trio.c
@@ -76,7 +76,7 @@
 #if !defined(TRIO_COMPILER_SUPPORTS_C99)
 # define isblank(x) (((x)==32) || ((x)==9))
 #endif
-#include <math.h>
+#include <cmath>
 #include <limits.h>
 #include <float.h>
 #if defined(TRIO_COMPILER_ANCIENT)

--- a/trio/trionan.c
+++ b/trio/trionan.c
@@ -43,7 +43,7 @@
 #include "triodef.h"
 #include "trionan.h"
 
-#include <math.h>
+#include <cmath>
 #include <string.h>
 #include <limits.h>
 #include <float.h>

--- a/trio/triostr.c
+++ b/trio/triostr.c
@@ -23,7 +23,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
-#include <math.h>
+#include <cmath>
 #include "triodef.h"
 #include "triostr.h"
 


### PR DESCRIPTION
- Replace "math.h" includes with "cmath".
This should fix https://github.com/lavv17/lftp/issues/273.
- Delete includes of "strftime.h". This is because this file only includes the function _nstrftime_, which is not used anywhere.
This should fix https://github.com/lavv17/lftp/issues/535.

Note that this PR doesn't fix all known compilation issues (specifically, https://github.com/lavv17/lftp/issues/376 remains, and it will probably fail the Travis CI build for this PR).