### PR TITLE
Fix build with --disable-ipv6

### DIFF
--- a/src/ftpclass.cc
+++ b/src/ftpclass.cc
@@ -848,6 +848,7 @@ Ftp::pasv_state_t Ftp::Handle_EPSV_CEPR()
       conn->data_sa.in.sin_port=htons(port);
       conn->data_sa.sa.sa_family=AF_INET;
    }
+#if INET6
    // V6 / AF_INET6
    else if (proto == 2)
    {
@@ -855,6 +856,7 @@ Ftp::pasv_state_t Ftp::Handle_EPSV_CEPR()
       conn->data_sa.in6.sin6_port=htons(port);
       conn->data_sa.sa.sa_family=AF_INET6;
    }
+#endif
    else
    {
       Disconnect("unsupported address family");


### PR DESCRIPTION
Otherwise this fails with:
```
ftpclass.cc: In member function ‘Ftp::pasv_state_t Ftp::Handle_EPSV_CEPR()’:
ftpclass.cc:854:53: error: ‘union sockaddr_u’ has no member named ‘in6’; did you mean ‘in’?
  854 |       inet_pton(AF_INET6, pasv_addr, &conn->data_sa.in6.sin6_addr);
      |                                                     ^~~
      |                                                     in
ftpclass.cc:855:21: error: ‘union sockaddr_u’ has no member named ‘in6’; did you mean ‘in’?
  855 |       conn->data_sa.in6.sin6_port=htons(port);
      |                     ^~~
      |                     in
```