### PR TITLE
m4/lftp_lib_readline.m4: fix static link with readline

### DIFF
--- a/m4/lftp_lib_readline.m4
+++ b/m4/lftp_lib_readline.m4
@@ -108,7 +108,9 @@ AC_DEFUN([lftp_LIB_READLINE],
 	    readline_include_dir="$readline_include_dir/readline"
 	fi
         readline_ld_flags="-L$readline_prefix/lib"
-        readline_lib_flags="-lreadline"
+        if test -z "$readline_lib_flags"; then
+            readline_lib_flags="-lreadline"
+        fi
         run_readline_test="yes"
     elif test "$readline_requested" = "yes"; then
         if test -n "$readline_include_dir" -a -n "$readline_lib_flags"; then


### PR DESCRIPTION
When readline is static library, we need to link against ncurses
because readline needs ncurses. It is because, dependent library's
symbols are not resolved when static library is built. Those symbols
are resolved program tries to link with static library.

We can't pass linker flags for ncurses by setting LIBS environment
variable via <PKG>_CONF_ENV because it looks like build system is not
taking that into account and even though it would have been, order of
linking is important.

We can't also pass linker flags for ncurses via --with-readline-libs
conf options because it causes lftp_LIB_READLINE macro to take readline
headers from host machine if available. To use --with-readline-libs
we need to set --with-readline=yes and --with-readline-inc to include
dir. But when --with-readline=yes, readline_prefix is computed based
on if headers can be found in /usr/local or /usr. If readline is
installed on host machine, then configure fails since we are using
headers for host machine. If headers are not found in /usr/local or /usr
then only path specified --with-readline-inc is taken into account.
So specifying linker flags for ncurses via --with-readline-libs will
not work in all cases.

To fix this error, do not override readline_lib_flags if it has been
set by --with-readline-lib

Signed-off-by: Rahul Bedarkar <rahul.bedarkar@imgtec.com>
[Retrieved (and slightly updated) from:
https://git.buildroot.net/buildroot/tree/package/lftp/0001-fix-static-link-with-readline.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>