### PR TITLE
Resume partial writes in gnutls_bye()

### DIFF
--- a/src/lftp_ssl.cc
+++ b/src/lftp_ssl.cc
@@ -354,6 +354,7 @@ int lftp_ssl_gnutls::shutdown()
 	         set_error("gnutls_shutdown",gnutls_strerror(res));
 	         return ERROR;
          }
+    return res;
    }
    return res;
 }

--- a/src/lftp_ssl.h
+++ b/src/lftp_ssl.h
@@ -110,7 +110,7 @@ public:
    bool want_out();
    void copy_sid(const lftp_ssl_gnutls *);
    void load_keys();
-   void shutdown();
+   int shutdown();
 };
 typedef lftp_ssl_gnutls lftp_ssl;
 #elif USE_OPENSSL
@@ -146,7 +146,7 @@ public:
    bool want_out();
    void copy_sid(const lftp_ssl_openssl *);
    void load_keys();
-   void shutdown();
+   int shutdown();
 };
 typedef lftp_ssl_openssl lftp_ssl;
 #endif


### PR DESCRIPTION
This pull request should make lftp resume partial writes that happen in gnutls_bye() on SSL shutdown.

A partial write on SSL shutdown can cause problems with some FTPS servers, e.g. IIS on Windows.

This is my first pull request to lftp, any feedback welcome.
