### PR TITLE
Bump autoconf minimum version to 2.64

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 dnl Process this file with autoconf to produce a configure script.
-AC_PREREQ([2.63])
+AC_PREREQ([2.64])
 AC_INIT([lftp],m4_esyscmd([build-aux/git-version-gen .tarball-version]),[lftp-bugs@lftp.yar.ru])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_MACRO_DIR([m4])


### PR DESCRIPTION
See: https://github.com/coreutils/gnulib/blob/master/NEWS#L6

Otherwise the building process show errors:
```
./bootstrap: Bootstrapping from checked-out lftp sources...
./bootstrap: consider installing git-merge-changelog from gnulib
./bootstrap: getting gnulib files...
Cloning into 'gnulib'...
remote: Counting objects: 10343, done.
remote: Compressing objects: 100% (9028/9028), done.
remote: Total 10343 (delta 5355), reused 2904 (delta 1293)
Receiving objects: 100% (10343/10343), 8.83 MiB | 242.00 KiB/s, done.
Resolving deltas: 100% (5355/5355), done.
Updating files: 100% (10273/10273), done.
./bootstrap: autopoint --force
Copying file ABOUT-NLS
Copying file build-aux/config.rpath
Copying file m4/codeset.m4
Copying file m4/gettext.m4
Copying file m4/glibc2.m4
Copying file m4/glibc21.m4
Copying file m4/iconv.m4
Copying file m4/intdiv0.m4
Copying file m4/intmax.m4
Copying file m4/inttypes-h.m4
Copying file m4/inttypes-pri.m4
Copying file m4/inttypes_h.m4
Copying file m4/lcmessage.m4
Copying file m4/lib-ld.m4
Copying file m4/lib-link.m4
Copying file m4/lib-prefix.m4
Copying file m4/lock.m4
Copying file m4/longdouble.m4
Copying file m4/longlong.m4
Copying file m4/nls.m4
Copying file m4/po.m4
Copying file m4/printf-posix.m4
Copying file m4/progtest.m4
Copying file m4/signed.m4
Copying file m4/size_max.m4
Copying file m4/stdint_h.m4
Copying file m4/uintmax_t.m4
Copying file m4/ulonglong.m4
Copying file m4/visibility.m4
Copying file m4/wchar_t.m4
Copying file m4/wint_t.m4
Copying file m4/xsize.m4
Copying file po/Makefile.in.in
Copying file po/Makevars.template
Copying file po/Rules-quot
Copying file po/boldquot.sed
Copying file po/en@boldquot.header
Copying file po/en@quot.header
Copying file po/insert-header.sin
Copying file po/quot.sed
Copying file po/remove-potcdate.sin
running: libtoolize --install --copy
libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
libtoolize: copying file 'build-aux/config.guess'
libtoolize: copying file 'build-aux/config.sub'
libtoolize: copying file 'build-aux/install-sh'
libtoolize: copying file 'build-aux/ltmain.sh'
libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'.
libtoolize: copying file 'm4/libtool.m4'
libtoolize: copying file 'm4/ltoptions.m4'
libtoolize: copying file 'm4/ltsugar.m4'
libtoolize: copying file 'm4/ltversion.m4'
libtoolize: copying file 'm4/lt~obsolete.m4'
./bootstrap: gnulib/gnulib-tool    --no-changelog   --aux-dir=build-aux   --doc-base=doc   --lib=libgnu   --m4-base=m4/   --source-base=lib/   --tests-base=tests   --local-dir=gl      --libtool --import ...
gnulib/gnulib-tool: *** minimum supported autoconf version is 2.64. Try adding AC_PREREQ([2.64]) to your configure.ac.
gnulib/gnulib-tool: *** Stop.
./bootstrap: gnulib-tool failed
```