### PR TITLE
Fix build with LibreSSL (following commit 537f37898)

### DIFF
--- a/src/lftp_ssl.cc
+++ b/src/lftp_ssl.cc
@@ -34,7 +34,7 @@
 #include "misc.h"
 #include "network.h"
 #include "buffer.h"
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || LIBRESSL_VERSION_NUMBER
 #define X509_STORE_CTX_get_by_subject X509_STORE_get_by_subject
 #endif
 extern "C" {
@@ -840,7 +840,7 @@ lftp_ssl_openssl_instance::lftp_ssl_openssl_instance()
    ssl_ctx=SSL_CTX_new();
    X509_set_default_verify_paths(ssl_ctx->cert);
 #else
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || LIBRESSL_VERSION_NUMBER
    SSLeay_add_ssl_algorithms();
 #endif
    ssl_ctx=SSL_CTX_new(SSLv23_client_method());
@@ -1080,7 +1080,7 @@ void lftp_ssl_openssl::copy_sid(const lftp_ssl_openssl *o)
 
 const char *lftp_ssl_openssl::strerror()
 {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || LIBRESSL_VERSION_NUMBER
    SSL_load_error_strings();
 #endif
    int error=ERR_get_error();


### PR DESCRIPTION
Hello,

This patch fixes the following build errors with LibreSSL (3.1.4) :

```
/bin/sh ../libtool --silent  --tag=CXX   --mode=compile c++ -DHAVE_CONFIG_H -I. -I../lib  -I../lib -I../trio  -I/usr/include  -DLIBICONV_PLUG -I/usr/local/include -isystem /usr/local/include -D_THREAD_SAFE  -O2 -pipe -DLIBICONV_PLUG -fstack-protector-strong -isystem /usr/local/include -fno-strict-aliasing  -DLIBICONV_PLUG -isystem /usr/local/include  -Wall -Wwrite-strings -Woverloaded-virtual -fno-exceptions -fno-rtti -fno-implement-inlines -MT liblftp_network_la-lftp_ssl.lo -MD -MP -MF .deps/liblftp_network_la-lftp_ssl.Tpo -c -o liblftp_network_la-lftp_ssl.lo `test -f 'lftp_ssl.cc' || echo './'`lftp_ssl.cc
lftp_ssl.cc:1164:10: error: use of undeclared identifier 'X509_STORE_CTX_get_by_subject'; did you mean 'X509_STORE_get_by_subject'?
    rc = X509_STORE_CTX_get_by_subject(store_ctx, X509_LU_CRL, subject, obj);
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         X509_STORE_get_by_subject
/usr/local/include/openssl/x509_vfy.h:479:5: note: 'X509_STORE_get_by_subject' declared here
int X509_STORE_get_by_subject(X509_STORE_CTX *vs,int type,X509_NAME *name,
    ^
lftp_ssl.cc:1204:10: error: use of undeclared identifier 'X509_STORE_CTX_get_by_subject'; did you mean 'X509_STORE_get_by_subject'?
    rc = X509_STORE_CTX_get_by_subject(store_ctx, X509_LU_CRL, issuer, obj);
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         X509_STORE_get_by_subject
/usr/local/include/openssl/x509_vfy.h:479:5: note: 'X509_STORE_get_by_subject' declared here
int X509_STORE_get_by_subject(X509_STORE_CTX *vs,int type,X509_NAME *name,
    ^
2 errors generated.
*** Error code 1
```
