### PR TITLE
the domain lftp.tech is dead -> switching back to former homepage lftp.yar.ru

### DIFF
--- a/tests/http-get.cc
+++ b/tests/http-get.cc
@@ -13,7 +13,7 @@ int main(int argc,char **argv)
    ResMgr::Set("log:level",0,"5");
    ResMgr::Set("log:enabled",0,"true");
 
-   FileAccess *f=FileAccess::New("http","lftp.tech");
+   FileAccess *f=FileAccess::New("http","lftp.yar.ru");
    if(!f)
    {
       fprintf(stderr,"http: unknown protocol, cannot create http session\n");


### PR DESCRIPTION
the former lftp homepage lftp.tech is now a parked domain: https://lftp.tech
Changing the test back to the project homepage.