### PR TITLE
Ensure that PollVec enum matches poll values

### DIFF
--- a/src/PollVec.h
+++ b/src/PollVec.h
@@ -59,8 +59,8 @@ public:
    void	 Block();
 
    enum {
-      IN=1,
-      OUT=4,
+      IN=POLLIN,
+      OUT=POLLOUT,
    };
 
    void SetTimeout(const timeval &t) { tv_timeout=t; }


### PR DESCRIPTION
IN and OUT are used by PollVec mask functions to determine which fd_sets
to use in AddFD, FDReady, and FDSetNotReady, however these enums are not
used outside of PollVec code and the rest of the code uses POLLIN and
POLLOUT definitions instead. This works on many POSIX platforms since
the enum values match the POLLIN and POLLOUT values, but not on AIX
where POLLOUT is 2 instead of 4. This prevents code from determining
when a file descriptor is writeable, leading to a hang when using FTPS
protocol (at least).

Fixes #672