### PR TITLE
more precise documentation for ssl:priority

### DIFF
--- a/doc/lftp.1
+++ b/doc/lftp.1
@@ -39,7 +39,7 @@
 .RE
 .fi
 ..
-.TH lftp 1 "10 Aug 2017"
+.TH lftp 1 "11 June 2022"
 .SH NAME
 lftp \- Sophisticated file transfer program
 .SH SYNTAX
@@ -2326,11 +2326,16 @@ Certificate Authority and not be on Certificate Revocation List. You can
 specify either host name or certificate fingerprint in the closure.
 .TP
 .BR ssl:priority " (string)"
-free form priority string for GnuTLS. If built with OpenSSL the understood
-values are \fI+\fP or \fI\-\fP followed by SSL3.0, TLS1.0, TLS1.1 or TLS1.2,
-separated by \fI:\fP. Example:
+free form priority string for GnuTLS. Example for TLS 1.2:
 .Ds
-set ssl:priority "NORMAL:\-SSL3.0:\-TLS1.0:\-TLS1.1:+TLS1.2"
+set ssl:priority "NORMAL:\-VERS\-SSL3.0:\-VERS\-TLS1.0:\-VERS\-TLS1.1:+VERS\-TLS1.2:\-VERS-TLS1.3"
+.De
+.RS
+If built with OpenSSL an emulated version is \fI\-\fP (\fI\+\fP has no effect) followed by SSL3.0, TLS1.0, TLS1.1, TLS1.2,
+separated by \fB:\fP. Example for TLS 1.3:
+.RE
+.Ds
+set ssl:priority "NORMAL:\-SSL3.0:\-TLS1.0:\-TLS1.1:-TLS1.2"
 .De
 .TP
 .BR torrent:ip " (ipv4 address)"


### PR DESCRIPTION
with examples for both GnuTLS and OpenSSL

rationale: inexperimented user of lftp I naively pasted the example from manual in the lftp config file and it did not work
(as the syntax for GnuTLS differs)