### PR TITLE
lftp_ssl: deinitialize the lftp_ssl_openssl_instance

### DIFF
--- a/src/lftp_ssl.cc
+++ b/src/lftp_ssl.cc
@@ -863,6 +863,7 @@ lftp_ssl_openssl::~lftp_ssl_openssl()
 {
    SSL_free(ssl);
    ssl=0;
+   global_deinit();
 }
 
 static lftp_ssl_openssl *verify_callback_ssl;


### PR DESCRIPTION
If the instance isn't deinitialized prior to exit, the OPENSSL_cleanup exit handler may run before the
lftp_ssl_openssl_instance destructor on exit resulting in a segfault.

This fixes a null deref on exit.

Fixes #716