### PR TITLE
configure.ac: Bump gettext version to 0.21

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -138,7 +138,7 @@ AM_ICONV
 
 ALL_LINGUAS="de es fr it ja ko pl pt_BR sr ru uk zh_CN zh_TW zh_HK cs"
 AM_GNU_GETTEXT([external])
-AM_GNU_GETTEXT_VERSION([0.15])
+AM_GNU_GETTEXT_VERSION([0.21])
 test "$MSGFMT"  = "no" && MSGFMT  ="$missing_dir/missing msgfmt"
 test "$GMSGFMT" = "no" && GMSGFMT ="$missing_dir/missing msgfmt"
 test "$XGETTEXT" = ":" && XGETTEXT="$missing_dir/missing xgettext"


### PR DESCRIPTION
After running autoreconf and configure on Ubuntu 24.04 (noble), the generated `po/Makefile` will fail to run `make install`:

```
$ make install DESTDIR=debian/lftp
[...]
Making install in po
make[4]: Entering directory 'po'
debian/lftp/usr/share
make[4]: debian/lftp/usr/share: Permission denied
```

This failure is caused by `mkdir_p` pointing to `MKDIR_P` but `MKDIR_P` not being defined in `po/Makefile`.

Upgrade to gettext version to 0.21. Then `po/Makefile` will be correct:

```
MKDIR_P = /usr/bin/mkdir -p
mkdir_p = $(MKDIR_P)
```