### PR TITLE
Attempt to fix SFTP issue #636 Too many out-of-order packets.

### DIFF
--- a/src/SFtp.h
+++ b/src/SFtp.h
@@ -755,6 +755,7 @@ private:
    int size_read;
    int size_write;
    bool use_full_path;
+   int max_out_of_order;
 
 protected:
    void SetError(int code,const Packet *reply);


### PR DESCRIPTION
lftp supports making many SFTP DATA requests in parallel when downloading a file. Responses with data payloads from an sftp server can sometimes arrive in a different order from the original requests.

The out of order data payload (packets) are added to the `ooo_chain` to be processed when the expected (but late) next requested packet arrives.

A single packet being delayed while many parallel requests continue to be made can sometimes result in the `Too many out-of-order packets` message if the `ooo_chain` buffer of 64 entries is exceeded.

This fix checks the remaining capacity of the `ooo_chain` and pending requests (`RespQueueSize()`) and will avoid sending new requests for more data until the `ooo_chain` is processed or `RespQueueSize()` shrinks. Adding this constraint does mean that `sftp:max-packets-in-flight` will be limited to the current `ooo_chain` length of 64.

I was able to reliably reproduce the issue with a 4gb download and verify the fix.