### PR TITLE
Add option for skipping FSETSTAT

### DIFF
--- a/doc/lftp.1
+++ b/doc/lftp.1
@@ -2293,6 +2293,10 @@ Block size for reading. Default is 0x8000.
 .BR sftp:size-write \ (number)
 Block size for writing. Default is 0x8000.
 .TP
+.BR sftp:skip-fsetstat \ (boolean)
+When true, lftp will NOT send FSETSTAT after finishing write of a file. Default is
+to send FSETSTAT after write and before close.
+.TP
 .BR ssl:ca-file " (path to file)"
 use specified file as Certificate Authority certificate.
 .TP

--- a/src/SFtp.h
+++ b/src/SFtp.h
@@ -755,6 +755,7 @@ private:
    int size_read;
    int size_write;
    bool use_full_path;
+   bool skip_fsetstat;
    int max_out_of_order;
 
 protected:


### PR DESCRIPTION
I've come across SFTP servers that (as a questionable decision):

1. Don't support `FSETSTAT`; and
2. Consider any failed operation during a transfer a failure of the transfer - keeping the transferred file in a staging directory (to be later cleaned up) instead of moving it to its final destination.

This PR adds a configuration parameter for SFTP to skip sending `FSETSTAT` after the file is written.