### PR TITLE
Fix Solaris build

### DIFF
--- a/src/lftp_tinfo.cc
+++ b/src/lftp_tinfo.cc
@@ -20,7 +20,7 @@
 #include <config.h>
 
 extern "C" {
-#if defined(HAVE_CURSES_H)
+#if defined(HAVE_CURSES_H) && !defined(__sun__)
 # include <curses.h>
 # if defined(HAVE_TERM_H)
 #  include <term.h>


### PR DESCRIPTION
Fixes problems like this:
```
/usr/gcc/14/include/c++/14.2.0/bits/char_traits.h:153:67: error: macro "move" passed 3 arguments, but takes just 2
  153 |       move(char_type* __s1, const char_type* __s2, std::size_t __n);
      |                                                                   ^
In file included from /builds/psumbera/userland-lftp-4.9.3/components/lftp/lftp-4.9.3/src/lftp_tinfo.cc:24:
/usr/gcc/14/lib/gcc/x86_64-pc-solaris2.11/14.2.0/include-fixed/curses.h:731:9: note: macro "move" defined here
  731 | #define move(y, x)      wmove(stdscr, y, x)
      |         ^~~~
/usr/gcc/14/include/c++/14.2.0/bits/char_traits.h:223:65: error: macro "move" passed 3 arguments, but takes just 2
  223 |     move(char_type* __s1, const char_type* __s2, std::size_t __n)
      |                                                                 ^
/usr/gcc/14/lib/gcc/x86_64-pc-solaris2.11/14.2.0/include-fixed/curses.h:731:9: note: macro "move" defined here
  731 | #define move(y, x)      wmove(stdscr, y, x)
      |         ^~~~
```