### PR TITLE
fix stack corruption in `cd` for relative paths due to added prefix length

### DIFF
--- a/src/ftpclass.cc
+++ b/src/ftpclass.cc
@@ -651,7 +651,7 @@ int Ftp::SendCWD(const char *path,const char *path_url,Expect::expect_t c)
       }
    } else {
       char *path1=alloca_strdup(path); // to split it
-      char *path2=alloca_strdup(path); // to re-assemble
+      char *path2=alloca_strdup2(path, 2); // to re-assemble + add space for potential ~/ prefix
       if(AbsolutePath(path)) {
 	 if(real_cwd && !strncmp(real_cwd,path,real_cwd.length())
 	 && path[real_cwd.length()]=='/') {


### PR DESCRIPTION
when the current path is not absolute, the implementation prefixes the target directory to change to with ~/
this is 2 more characters than allocated, hence we write beyond the buffer boundary.

in order to fix this, we allocate two more characters for the reconstruction buffer, so it can hold a relative path prefixed with ~/ as well.

fixes #734