### PR TITLE
allow build with OpenSSL 4.x

### DIFF
--- a/src/lftp_ssl.cc
+++ b/src/lftp_ssl.cc
@@ -1022,8 +1022,8 @@ const char *lftp_ssl_openssl::strerror()
 int lftp_ssl_openssl::verify_crl(X509_STORE_CTX *ctx)
 {
     X509_OBJECT *obj=0;
-    X509_NAME *subject=0;
-    X509_NAME *issuer=0;
+    const X509_NAME *subject=0;
+    const X509_NAME *issuer=0;
     X509 *xs=0;
     X509_CRL *crl=0;
     X509_REVOKED *revoked=0;
@@ -1436,7 +1436,7 @@ void lftp_ssl_openssl::check_certificate()
     unsigned char *nulstr = (unsigned char *)"";
     unsigned char *peer_CN = nulstr;
 
-    X509_NAME *name = X509_get_subject_name(server_cert) ;
+    const X509_NAME *name = X509_get_subject_name(server_cert) ;
     if(name)
       while((j = X509_NAME_get_index_by_NID(name, NID_commonName, i))>=0)
         i=j;
@@ -1446,7 +1446,7 @@ void lftp_ssl_openssl::check_certificate()
        UTF8 etc. */
 
     if(i>=0) {
-      ASN1_STRING *tmp = X509_NAME_ENTRY_get_data(X509_NAME_get_entry(name,i));
+      const ASN1_STRING *tmp = X509_NAME_ENTRY_get_data(X509_NAME_get_entry(name,i));
 
       /* In OpenSSL 0.9.7d and earlier, ASN1_STRING_to_UTF8 fails if the input
          is already UTF-8 encoded. We check for this case and copy the raw
@@ -1522,8 +1522,8 @@ int lftp_ssl_openssl::verify_callback(int ok,X509_STORE_CTX *ctx)
    if(cert!=prev_cert)
    {
       int depth          = X509_STORE_CTX_get_error_depth(ctx);
-      X509_NAME *subject = X509_get_subject_name(cert);
-      X509_NAME *issuer  = X509_get_issuer_name(cert);
+      const X509_NAME *subject = X509_get_subject_name(cert);
+      const X509_NAME *issuer  = X509_get_issuer_name(cert);
       char *subject_line = X509_NAME_oneline(subject, NULL, 0);
       char *issuer_line  = X509_NAME_oneline(issuer, NULL, 0);
       Log::global->Format(3,"Certificate depth: %d; subject: %s; issuer: %s\n",


### PR DESCRIPTION
- Fixes #775 
- https://github.com/openssl/openssl/releases/tag/openssl-4.0.0-alpha1
  - Signatures of numerous API functions, including those that are related
to X509 processing, are changed to include const qualifiers for argument
and return types, where suitable.
