### PR TITLE
mirror: use xfer:destination-directory as default target directory

### DIFF
--- a/doc/lftp.1
+++ b/doc/lftp.1
@@ -2403,7 +2403,7 @@ if this setting is off, get commands will not overwrite existing
 files and generate an error instead.
 .TP
 .BR xfer:destination-directory " (path or URL to directory)"
-This setting is used as default \-O option for get and mget commands.
+This setting is used as default \-O option for get, mget and mirror commands.
 Default is empty, which means current directory (no \-O option).
 .TP
 .BR xfer:disk-full-fatal \ (boolean)

--- a/src/MirrorJob.cc
+++ b/src/MirrorJob.cc
@@ -2226,7 +2226,16 @@ CMD(mirror)
       source_dir=".";
    }
    if(!target_dir)
-      target_dir=".";
+   {
+      if(!reverse)
+      {
+	 const char *od=ResMgr::Query("xfer:destination-directory",parent->session->GetHostName());
+	 if(od && *od)
+	    target_dir=od;
+      }
+      if(!target_dir)
+	 target_dir=".";
+   }
 
    if(!reverse)
    {


### PR DESCRIPTION
Closes #690

Having `mirror` use `xfer:destination-directory` makes things easier.

Updated man page accordingly.